### PR TITLE
Export a const enum so the structure compiles away

### DIFF
--- a/Key.enum.ts
+++ b/Key.enum.ts
@@ -4,7 +4,7 @@
   * but does not include values like "a", "A", "#", "é", or "¿".
   * Auto generated from MDN: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Speech_recognition_keys
   */
-export enum Key {
+export const enum Key {
 
     /** The user agent wasn't able to map the event's virtual keycode to a specific key value. This can happen due to hardware or software constraints, or because of constraints around the platform on which the user agent is running. */
     Unidentified = 'Unidentified',

--- a/scrapeMDNForKeys.ts
+++ b/scrapeMDNForKeys.ts
@@ -73,7 +73,7 @@ const writeFileAsync = bluebird.promisify(writeFile);
         `  * but does not include values like "a", "A", "#", "é", or "¿".\n` +
         `  * Auto generated from MDN: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values#Speech_recognition_keys\n` +
         `  */\n` +
-        `export enum Key {\n\n` +
+        `export const enum Key {\n\n` +
         keys
             .map(k => {
                 // prettier-ignore


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/enums.html#const-enums for the benefits of using a `const enum`. In short, the enum is no longer generated and its members are statically replaced wherever used. You get the benefit of the type-checker ensuring you're using the right keys but no overhead of extra code (I'm only using 5-6 codes but otherwise I have the entire enum in the compiled output). Of course you'll also need to distribute the typescript file to the npm package so people installing the package there can take advantage of that - I didn't work that bit out yet.